### PR TITLE
chore: update comrak, crossterm, notify-debouncer-mini, tao, ureq, wry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ tui-backend = ["dep:ratatui", "dep:crossterm", "dep:ratatui-image", "dep:image",
 [dependencies]
 # Core
 clap = { version = "4", features = ["derive"] }
-comrak = { version = "0.38", default-features = false, features = ["syntect"] }
+comrak = { version = "0.50", default-features = false, features = ["syntect"] }
 notify = "8"
-notify-debouncer-mini = "0.6"
+notify-debouncer-mini = "0.7"
 mermaid-rs-renderer = { version = "0.1.2", default-features = false }
 regex = "1"
 serde_json = "1"
@@ -36,15 +36,15 @@ usvg = { version = "0.45", optional = true }
 tiny-skia = { version = "0.11", optional = true }
 
 # webview backend
-wry = { version = "0.50", optional = true }
-tao = { version = "0.33", optional = true }
+wry = { version = "0.54", optional = true }
+tao = { version = "0.34", optional = true }
 
 # tui backend
 ratatui = { version = "0.29", optional = true }
-crossterm = { version = "0.28", optional = true }
+crossterm = { version = "0.29", optional = true }
 ratatui-image = { version = "4.1", optional = true }
 image = { version = "0.25", optional = true, default-features = false, features = ["png", "jpeg", "gif", "webp"] }
-ureq = { version = "2", optional = true }
+ureq = { version = "3", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/backend/tui.rs
+++ b/src/backend/tui.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self, Read};
 use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 
@@ -748,7 +748,7 @@ fn rasterize_svg(svg_data: &str) -> Result<image::DynamicImage, Box<dyn std::err
 fn load_image_from_http(url: &str) -> Result<image::DynamicImage, Box<dyn std::error::Error>> {
     let response = ureq::get(url).call()?;
     let mut bytes = Vec::new();
-    response.into_reader().read_to_end(&mut bytes)?;
+    response.into_body().into_reader().read_to_end(&mut bytes)?;
     let img = image::load_from_memory(&bytes)?;
     Ok(img)
 }

--- a/src/core/markdown.rs
+++ b/src/core/markdown.rs
@@ -11,7 +11,7 @@ pub fn parse_markdown(content: &str) -> String {
     options.extension.autolink = true;
     options.extension.tasklist = true;
     options.extension.footnotes = true;
-    options.render.unsafe_ = true;
+    options.render.r#unsafe = true;
 
     let html = markdown_to_html(content, &options);
     let html = add_heading_ids(&html);


### PR DESCRIPTION
This pull request primarily updates several dependencies in `Cargo.toml` to their latest versions and makes minor code adjustments to accommodate these updates. I've only updated dependencies which don't need important code change to keep tests OK.

The changes aim to keep the project up-to-date and compatible with the latest features and fixes in upstream libraries.

**Dependency updates:**

* Updated core and backend dependencies in `Cargo.toml`, including `comrak` (0.38 → 0.50), `notify-debouncer-mini` (0.6 → 0.7), `wry` (0.50 → 0.54), `tao` (0.33 → 0.34), `crossterm` (0.28 → 0.29), and `ureq` (2 → 3). [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L23-R25) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L39-R47)

**Code compatibility adjustments:**

* Changed the import in `src/backend/tui.rs` to include `Read` from `std::io` to support updated usage.
* Updated the HTTP image loading function in `src/backend/tui.rs` to use `response.into_body().into_reader()` in line with the new `ureq` API.
* Modified the `comrak` markdown rendering option from `unsafe_` to `r#unsafe` in `src/core/markdown.rs` to match the new version’s struct field naming.