### PR TITLE
Fix webview backend crash on Linux/Wayland

### DIFF
--- a/src/backend/webview.rs
+++ b/src/backend/webview.rs
@@ -74,6 +74,17 @@ pub fn run(file_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_os = "macos")]
     menu.init_for_nsapp();
 
+    #[cfg(target_os = "linux")]
+    let webview = {
+        use tao::platform::unix::WindowExtUnix;
+        use wry::WebViewBuilderExtUnix;
+        let vbox = window.default_vbox().unwrap();
+        WebViewBuilder::new()
+            .with_html(&full_html)
+            .with_clipboard(true)
+            .build_gtk(vbox)?
+    };
+    #[cfg(not(target_os = "linux"))]
     let webview = WebViewBuilder::new()
         .with_html(&full_html)
         .with_clipboard(true)


### PR DESCRIPTION
Love the app, thanks for putting it together CleverCloud!

On Linux under Wayland, tao returns a RawWindowHandle::Wayland handle which wry's WebViewBuilder::build(&window) does not support, producing "the window handle kind is not supported" at runtime.

Fix by using wry's GTK-native API (WebViewBuilderExtUnix::build_gtk) on Linux, which attaches to tao's internal GTK VBox and works with both X11 and Wayland backends. Non-Linux platforms continue to use the existing build(&window) path.