### PR TITLE
Feat/config and fonts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ mermaid-rs-renderer = { version = "0.1.2", default-features = false }
 regex = "1"
 serde_json = "1"
 base64 = "0.22"
+kdl = "6"
 
 # egui backend
 eframe = { version = "0.33", optional = true }

--- a/src/backend/webview.rs
+++ b/src/backend/webview.rs
@@ -74,6 +74,17 @@ pub fn run(file_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_os = "macos")]
     menu.init_for_nsapp();
 
+    #[cfg(target_os = "linux")]
+    let webview = {
+        use tao::platform::unix::WindowExtUnix;
+        use wry::WebViewBuilderExtUnix;
+        let vbox = window.default_vbox().unwrap();
+        WebViewBuilder::new()
+            .with_html(&full_html)
+            .with_clipboard(true)
+            .build_gtk(vbox)?
+    };
+    #[cfg(not(target_os = "linux"))]
     let webview = WebViewBuilder::new()
         .with_html(&full_html)
         .with_clipboard(true)

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,0 +1,157 @@
+use std::path::PathBuf;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_config(name: &str, content: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!("mdr_test_config_{}.kdl", name));
+        let _ = std::fs::remove_file(&path);
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn default_config_is_valid_kdl_v2() {
+        kdl::KdlDocument::parse_v2(DEFAULT_CONFIG)
+            .expect("DEFAULT_CONFIG must be valid KDL v2");
+    }
+
+    #[test]
+    fn load_parses_backend_unquoted() {
+        let path = tmp_config("backend", "backend webview\n");
+        let cfg = load(&path).unwrap();
+        assert_eq!(cfg.backend.as_deref(), Some("webview"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn load_parses_backend_quoted() {
+        let path = tmp_config("backend_quoted", "backend \"egui\"\n");
+        let cfg = load(&path).unwrap();
+        assert_eq!(cfg.backend.as_deref(), Some("egui"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn load_parses_verbose_bool() {
+        let path = tmp_config("verbose_true", "verbose #true\n");
+        let cfg = load(&path).unwrap();
+        assert_eq!(cfg.verbose, Some(true));
+
+        let path2 = tmp_config("verbose_false", "verbose #false\n");
+        let cfg2 = load(&path2).unwrap();
+        assert_eq!(cfg2.verbose, Some(false));
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&path2);
+    }
+
+    #[test]
+    fn load_bare_verbose_node_means_true() {
+        let path = tmp_config("verbose_bare", "verbose\n");
+        let cfg = load(&path).unwrap();
+        assert_eq!(cfg.verbose, Some(true));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn load_returns_defaults_for_missing_file() {
+        let path = PathBuf::from("/nonexistent/mdr_no_such_config.kdl");
+        let cfg = load(&path).unwrap();
+        assert!(cfg.backend.is_none());
+        assert!(cfg.verbose.is_none());
+    }
+
+    #[test]
+    fn write_default_creates_valid_kdl_v2_file() {
+        let path = std::env::temp_dir().join("mdr_test_config_write_default.kdl");
+        let _ = std::fs::remove_file(&path);
+        write_default(&path).unwrap();
+        assert!(path.exists());
+        let content = std::fs::read_to_string(&path).unwrap();
+        kdl::KdlDocument::parse_v2(&content)
+            .expect("written config must be valid KDL v2");
+        assert!(content.contains("backend webview"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn write_default_errors_if_file_exists() {
+        let path = tmp_config("write_exists", "// existing\n");
+        assert!(write_default(&path).is_err());
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+/// Resolved configuration from a KDL v2 config file.
+#[derive(Default, Debug)]
+pub struct Config {
+    pub backend: Option<String>,
+    pub verbose: Option<bool>,
+}
+
+const DEFAULT_CONFIG: &str = "\
+// mdr configuration — https://github.com/CleverCloud/mdr
+
+// Rendering backend: auto, egui, webview, tui
+backend webview
+
+// Uncomment to enable verbose logging by default
+// verbose #true
+";
+
+/// Returns the default config file path: `~/.config/mdr/config.kdl`.
+pub fn default_path() -> PathBuf {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".config/mdr/config.kdl")
+}
+
+/// Write the default config to `path`, creating parent directories as needed.
+/// Returns an error if the file already exists.
+pub fn write_default(path: &PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    if path.exists() {
+        return Err(format!(
+            "config file already exists at '{}' — delete it first to reinitialise",
+            path.display()
+        )
+        .into());
+    }
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    std::fs::write(path, DEFAULT_CONFIG)?;
+    Ok(())
+}
+
+/// Load config from `path`. Returns defaults if the file does not exist.
+/// Errors on parse failure.
+pub fn load(path: &PathBuf) -> Result<Config, Box<dyn std::error::Error>> {
+    if !path.exists() {
+        return Ok(Config::default());
+    }
+    let text = std::fs::read_to_string(path)?;
+    let doc = kdl::KdlDocument::parse_v2(&text)?;
+    let mut cfg = Config::default();
+    for node in doc.nodes() {
+        match node.name().value() {
+            "backend" => {
+                if let Some(kdl::KdlValue::String(s)) = node.get(0) {
+                    cfg.backend = Some(s.clone());
+                }
+            }
+            "verbose" => {
+                cfg.verbose = Some(match node.get(0) {
+                    None => true, // bare `verbose` node = true
+                    Some(kdl::KdlValue::Bool(b)) => *b,
+                    _ => true,
+                });
+            }
+            other => eprintln!("mdr: unknown config key '{}'", other),
+        }
+    }
+    Ok(cfg)
+}

--- a/src/core/markdown.rs
+++ b/src/core/markdown.rs
@@ -214,7 +214,7 @@ pub const GITHUB_CSS: &str = r#"
 * { box-sizing: border-box; }
 html, body { margin: 0; padding: 0; height: 100%; }
 body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
     font-size: 16px;
     line-height: 1.6;
     color: var(--fg);

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod icon;
 pub mod markdown;
 pub mod mermaid;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,16 +13,24 @@ struct Cli {
     file: Option<PathBuf>,
 
     /// Rendering backend to use: egui (native GUI), webview (HTML), tui (terminal)
-    #[arg(short, long, default_value = "auto", value_parser = parse_backend)]
-    backend: String,
+    #[arg(short, long, value_parser = parse_backend)]
+    backend: Option<String>,
 
     /// Enable verbose logging (image resolution, mermaid rendering, etc.)
     #[arg(short, long)]
     verbose: bool,
 
+    /// Path to config file [default: ~/.config/mdr/config.kdl]
+    #[arg(long, value_name = "PATH")]
+    config: Option<PathBuf>,
+
     /// List available backends and exit
     #[arg(long)]
     list_backends: bool,
+
+    /// Create a default config file and exit
+    #[arg(long)]
+    init: bool,
 }
 
 fn print_backends() {
@@ -105,12 +113,39 @@ fn read_stdin_to_tmpfile() -> PathBuf {
 
 fn main() {
     let cli = Cli::parse();
-    core::set_verbose(cli.verbose);
 
     if cli.list_backends {
         print_backends();
         process::exit(0);
     }
+
+    if cli.init {
+        let path = cli.config.clone().unwrap_or_else(core::config::default_path);
+        match core::config::write_default(&path) {
+            Ok(()) => {
+                eprintln!("Created config file: {}", path.display());
+                process::exit(0);
+            }
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                process::exit(1);
+            }
+        }
+    }
+
+    // Load config (explicit path errors if missing; default path is optional)
+    let cfg_path = cli.config.clone().unwrap_or_else(core::config::default_path);
+    let cfg = if cli.config.is_some() && !cfg_path.exists() {
+        eprintln!("Error: config file '{}' not found", cfg_path.display());
+        process::exit(1);
+    } else {
+        core::config::load(&cfg_path).unwrap_or_else(|e| {
+            eprintln!("mdr: config error ({}): {}", cfg_path.display(), e);
+            core::config::Config::default()
+        })
+    };
+
+    core::set_verbose(cli.verbose || cfg.verbose.unwrap_or(false));
 
     let file = match cli.file {
         Some(f) if f.as_os_str() == "-" => read_stdin_to_tmpfile(),
@@ -133,10 +168,13 @@ fn main() {
         }
     };
 
-    let backend = if cli.backend == "auto" {
+    let backend_str = cli.backend
+        .or(cfg.backend)
+        .unwrap_or_else(|| "auto".to_string());
+    let backend = if backend_str == "auto" {
         detect_backend()
     } else {
-        cli.backend.as_str()
+        backend_str.as_str()
     };
 
     let result = match backend {

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,0 +1,80 @@
+use std::process::Command;
+
+fn mdr_bin() -> std::path::PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // remove test binary name
+    path.pop(); // remove "deps"
+    path.push("mdr");
+    path
+}
+
+#[test]
+fn init_creates_config_at_custom_path() {
+    let path = std::env::temp_dir().join("mdr_test_init_creates.kdl");
+    let _ = std::fs::remove_file(&path);
+
+    let output = Command::new(mdr_bin())
+        .args(["--init", "--config"])
+        .arg(&path)
+        .output()
+        .expect("failed to run mdr");
+
+    assert!(output.status.success(), "mdr --init should succeed");
+    assert!(path.exists(), "config file should be created");
+
+    let content = std::fs::read_to_string(&path).unwrap();
+    assert!(content.contains("backend webview"), "config should set default backend");
+
+    // File must be valid KDL v2
+    kdl::KdlDocument::parse_v2(&content)
+        .expect("--init output must be valid KDL v2");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn init_errors_if_config_already_exists() {
+    let path = std::env::temp_dir().join("mdr_test_init_exists.kdl");
+    std::fs::write(&path, "// existing\n").unwrap();
+
+    let output = Command::new(mdr_bin())
+        .args(["--init", "--config"])
+        .arg(&path)
+        .output()
+        .expect("failed to run mdr");
+
+    assert!(!output.status.success(), "mdr --init should fail if config exists");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("already exists"),
+        "stderr should mention file already exists, got: {}",
+        stderr
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn explicit_missing_config_errors() {
+    // --config pointing to a nonexistent file (without --init) should error.
+    // We pass a markdown file too so that the process reaches config-loading.
+    let md = std::env::temp_dir().join("mdr_test_cfg_missing.md");
+    std::fs::write(&md, "# test\n").unwrap();
+
+    let output = Command::new(mdr_bin())
+        .arg("--config")
+        .arg("/nonexistent/mdr_no_such.kdl")
+        .arg(&md)
+        .output()
+        .expect("failed to run mdr");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not found"),
+        "should report config file not found, got: {}",
+        stderr
+    );
+
+    let _ = std::fs::remove_file(&md);
+}


### PR DESCRIPTION
Added the ability to set user config defaults in ~/.config/mdr/config.kdl. 
Set the default base font to be CSS 'system-ui', which is the modern recommended platform-neutral way of using the users' chosen desktop font.