### PR TITLE
Fix Windows CI hang: bail tui backend when stdout is not a TTY

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   check:
     name: Check (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/src/backend/tui.rs
+++ b/src/backend/tui.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Read};
+use std::io::{self, IsTerminal, Read};
 use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 
@@ -43,6 +43,13 @@ impl ContentElement {
 pub fn run(file_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     let content = std::fs::read_to_string(&file_path)?;
     let toc_entries = toc::extract_toc(&content);
+
+    // Bail out if stdout is not a TTY. On Unix, enable_raw_mode() errors on a
+    // pipe so the loop never starts; on Windows it succeeds and the event poll
+    // would spin forever (which previously hung CI for 6h).
+    if !io::stdout().is_terminal() {
+        return Err("tui backend requires a terminal (stdout is not a TTY)".into());
+    }
 
     // Setup terminal
     enable_raw_mode()?;


### PR DESCRIPTION
## Summary

Every CI run on `main` since PR #20 (Feb 2026) has been **cancelled at the 6h job timeout** on `windows-latest`. The Ubuntu and macOS jobs in the same matrix finish in ~16 min and ~11 min respectively, so the hang is Windows-specific.

## Root cause

The `tui` backend enters raw mode and starts polling events without checking that stdout is attached to a terminal:

```rust
enable_raw_mode()?;
execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
// ... loop { event::poll(...) ... }
```

- **On Unix**, `enable_raw_mode()` does `tcsetattr` on a pipe and returns `Err` — the binary exits cleanly, and `tests/stdin_pipe.rs::stdin_pipe_creates_temp_file` passes after the temp file is written.
- **On Windows**, `enable_raw_mode()` does `SetConsoleMode` against the console buffer that Actions runners always attach to spawned children, so it succeeds. The event poll then waits forever for keystrokes that will never come, the test hangs, `cargo test` hangs, and the job times out at 6h.

## Fix

1. `src/backend/tui.rs`: check `io::stdout().is_terminal()` at the top of `run()` and return an error before touching raw mode. Same observable behaviour as the Unix path today.
2. `.github/workflows/ci.yml`: add `timeout-minutes: 90` on the check job so a future regression fails fast.

## Verification

- `cargo test` locally — 109 unit + 3 config + 4 stdin_pipe tests pass
- `cargo build --no-default-features --features tui-backend` clean
- The CI run on this PR will confirm Windows now completes within the new 90-min budget

## Test plan

- [x] `cargo test` passes locally
- [ ] CI green on this PR for Windows (this is the assertion the PR exists to prove)
- [ ] Subsequent merge to main produces a green run

🤖 Generated with [Claude Code](https://claude.com/claude-code)